### PR TITLE
BDOG-1970 fix boottime ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ build/
 auto-save-list
 .\#*
 result
+.vscode/

--- a/ledger/statefile.go
+++ b/ledger/statefile.go
@@ -49,8 +49,11 @@ func loadStateFile(installDir string) (StateFile, error) {
 
 func clearStateFile(installDir string) error {
 	err := os.Remove(path.Join(installDir, stateFileName))
-	if err != nil && !os.IsNotExist(err) {
-		// dont care it it dont exist
+	if err != nil {
+		if os.IsNotExist(err) {
+			// dont care it it dont exist
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/servicemanager/status.go
+++ b/servicemanager/status.go
@@ -48,15 +48,6 @@ func (sm *ServiceManager) findStatuses() []serviceStatus {
 
 	// for each state file
 	for _, state := range states {
-		// ignore services that were started before the os started
-		if state.Started.Before(bootTime) {
-			// clean up state file
-			installDir, err := sm.findInstallDirOfService(state.Service)
-			if err != nil {
-				_ = sm.Ledger.ClearStateFile(installDir)
-			}
-			continue
-		}
 
 		status := serviceStatus{
 			pid:     state.Pid,
@@ -80,7 +71,17 @@ func (sm *ServiceManager) findStatuses() []serviceStatus {
 				}
 			}
 		} else {
-			// no pid
+			// service is not running...
+
+			// ignore services that were started before the os started
+			if state.Started.Before(bootTime) {
+				// clean up state file
+				installDir, err := sm.findInstallDirOfService(state.Service)
+				if err != nil {
+					_ = sm.Ledger.ClearStateFile(installDir)
+				}
+				continue
+			}
 			status.health = FAIL
 		}
 		statuses = append(statuses, status)


### PR DESCRIPTION
- BDOG-1943 adds support for custom healthcheck urls also removes Md5Sum from .state file (unused)
- Only ignore pre-boot services if they fail Rather than pre-emptively ignore them, wait until they actually fail
