### PR TITLE
BDOG 2129

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,19 @@ It's based on the the original [service-manager](https://github.com/hmrc/service
 
 **Linux**
 ```base
-curl -L -O https://github.com/hmrc/sm2/releases/download/v1.0.1/sm2-1.0.1-linux-intel.zip && unzip sm2-1.0.1-linux-intel.zip && rm sm2-1.0.1-linux-intel.zip
+curl -L -O https://github.com/hmrc/sm2/releases/download/v1.0.2/sm2-1.0.2-linux-intel.zip && unzip sm2-1.0.2-linux-intel.zip && rm sm2-1.0.2-linux-intel.zip
 ```
 
 **OSX/Apple (latest M1/M2 cpus)**
 
 ```base
-curl -L -O https://github.com/hmrc/sm2/releases/download/v1.0.1/sm2-1.0.1-apple-arm64.zip && unzip sm2-1.0.1-apple-arm64.zip && rm sm2-1.0.1-apple-arm64.zip
+curl -L -O https://github.com/hmrc/sm2/releases/download/v1.0.2/sm2-1.0.2-apple-arm64.zip && unzip sm2-1.0.2-apple-arm64.zip && rm sm2-1.0.2-apple-arm64.zip
 ```
 
 **OSX/Apple (older Intel cpus)**
 
 ```base
-curl -L -O https://github.com/hmrc/sm2/releases/download/v1.0.1/sm2-1.0.1-apple-intel.zip && unzip sm2-1.0.1-apple-intel.zip && rm sm2-1.0.1-apple-intel.zip
+curl -L -O https://github.com/hmrc/sm2/releases/download/v1.0.2/sm2-1.0.2-apple-intel.zip && unzip sm2-1.0.2-apple-intel.zip && rm sm2-1.0.2-apple-intel.zip
 ```
 
 If everything has worked you should have an executable called `sm2`. 

--- a/makefile
+++ b/makefile
@@ -8,7 +8,7 @@
 ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 BINARY := sm2
-VERSION := 1.0.1
+VERSION := 1.0.2
 BUILD := `git rev-parse HEAD`
 
 # Setup linker flags option for build that interoperate with variable names in src code

--- a/sm.go
+++ b/sm.go
@@ -21,7 +21,7 @@ func main() {
 	}
 
 	client := &http.Client{
-		Timeout: 120 * time.Second,
+		Timeout: 30 * time.Minute,
 	}
 
 	serviceManager := servicemanager.ServiceManager{


### PR DESCRIPTION
- BDOG-2192 makes default http timeout longer, adds ctx timeout on short requests
- 1.0.2 release updates
