### PR TITLE
"Starting 1 services on 2 workers" message doesn't seem to make sense

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ sm2 : /usr/local/bin/sm2
 From your terminal type:
 ```shell
 $ sm2 -start SERVICE_NAME
-Starting 1 services on 2 workers
+Starting 1 service
  SERVICE_NAME         [====================][100%] Done
 ```
 This will download the latest release of that service, configure it and start it up.

--- a/servicemanager/startservice.go
+++ b/servicemanager/startservice.go
@@ -330,7 +330,15 @@ func (sm *ServiceManager) asyncStart(services []ServiceAndVersion) {
 	sm.progress.init(services)
 	taskQueue := make(chan ServiceAndVersion, len(services))
 
-	fmt.Printf("Starting %d services on %d workers\n", len(services), sm.Commands.Workers)
+	if len(services) == 1 {
+		fmt.Printf("Starting 1 service\n")
+	} else {
+		workerPlural := ""
+		if sm.Commands.Workers != 1 {
+			workerPlural = "s"
+		}
+		fmt.Printf("Starting %d services on %d worker%s\n", len(services), sm.Commands.Workers, workerPlural)
+	}
 
 	// start up a number of workers (controlled by --workers param)
 	wg := sync.WaitGroup{}


### PR DESCRIPTION
- Print "Starting 1 service" if a user is starting only 1 service
- pluralise the word worker depending on whether 1 or more workers are used