### PR TITLE
Parameterise the co-ordinates of the sm2 config repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,23 @@ It's based on the the original [service-manager](https://github.com/hmrc/service
 
 ## Installing Service Manager
 
-### Installing From Binary
-The simplest way to install sm2 is by utilising the `install.sh` script. Run the following in your terminal:
+### Pre-requisites
+
+`sm2` expects a folder called `service-manager-config` to be present in the workspace (default `$HOME/.sm2/`).
+
+You can find out more [here](example/service-manager-config)
+
+### Installing using `install.sh`
+
+`install.sh` expects an argument that points to the git repository for your `service-manager-config`
+
+Replacing the placeholder git repository with your actual one, run the following in your terminal:
+
 ```shell
-bash <(curl -fksSL https://raw.githubusercontent.com/hmrc/sm2/main/install.sh)
+curl -fksSL https://raw.githubusercontent.com/hmrc/sm2/main/install.sh | bash -s -- "git@github.com:placeholderOrg/placeholderRepo.git"
 ```
+
+### Installing From Binary
 
 If you'd prefer to carry out these steps manually, then follow these steps:
 

--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,15 @@ if [[ "$(uname -p)" == "arm" ]]; then
     TARGET_ARCH="arm64"
 fi
 
+validate_args() {
+  if [[ -z "${1}" ]]; then
+      echo "Error: sm2-configuration-repository-specification parameter not provided."
+      echo
+      usage
+      exit 1
+  fi
+}
+
 download_sm2() {
   # https://unix.stackexchange.com/a/84980
   TEMPORARY_DIRECTORY=$(mktemp -d 2>/dev/null || mktemp -d -t 'sm2')
@@ -42,11 +51,7 @@ create_workspace_folder() {
 }
 
 clone_service_manager_config() {
-  if [[ -z "$1" ]]; then
-      CONFIG_REPO="git@github.com:hmrc/service-manager-config.git"
-  else
-      CONFIG_REPO="$1"
-  fi
+  CONFIG_REPO="${1}"
 
   CONFIG_FOLDER="${WORKSPACE_FOLDER}/service-manager-config"
   if [[ ! -d "${CONFIG_FOLDER}" ]]; then
@@ -61,7 +66,26 @@ clone_service_manager_config() {
   fi
 }
 
+usage() {
+  cat << EOF
+  NAME
+    sm2 installer
+
+  USAGE
+    install.sh [sm2-configuration-repository-specification]
+
+    Example:
+    install.sh "git@github.com:myorg/sm2-config.git"
+
+  PURPOSE
+    Installs Service Manager 2 (sm2).
+    Obtains the necessary SM2 configuration as indicated by [sm2-configuration-repository-specification].
+    Runs SM2 diagnostic utility, to verify correctness of sm2 installation.
+EOF
+}
+
 # Main
+validate_args "${@}"
 download_sm2
 create_workspace_folder
 clone_service_manager_config "${@}"


### PR DESCRIPTION
The CURL command to invoke the script with the sm2-config-repo as an argument now becomes:

```shell
curl -fksSL https://raw.githubusercontent.com/hmrc/sm2/BDOG-2827-parameterise-sm2-config-repo/install.sh | \
    bash -s -- "git@github.com:org/repo-name.git"
```