### PR TITLE
fix readme format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Service manager V2
+
 Service Manager 2 (sm2) is a tool to manager starting and stopping groups of scala/play microservices for local development and testing.
 It's based on the the original [service-manager](https://github.com/hmrc/service-manager) but re-written in golang.
 
@@ -26,23 +27,25 @@ If you'd prefer to carry out these steps manually, then follow these steps:
 
 1. Run the following command in your terminal for your operating system/cpu:
 
-**Linux Intel**
+#### Linux Intel
+
 ```shell
 curl -L -O https://github.com/hmrc/sm2/releases/download/v2.0.1/sm2-2.0.1-linux-intel.zip && unzip sm2-2.0.1-linux-intel.zip && rm sm2-2.0.1-linux-intel.zip && chmod +x sm2
 ```
 
-**Linux Arm64**
+#### Linux Arm64
+
 ```shell
 curl -L -O https://github.com/hmrc/sm2/releases/download/v2.0.1/sm2-2.0.1-linux-arm64.zip && unzip sm2-2.0.1-linux-arm64.zip && rm sm2-2.0.1-linux-arm64.zip && chmod +x sm2
 ```
 
-**OSX/Apple (latest M1/M2 cpus)**
+#### OSX/Apple (latest M1/M2/Mx cpus)
 
 ```shell
 curl -L -O https://github.com/hmrc/sm2/releases/download/v2.0.1/sm2-2.0.1-apple-arm64.zip && unzip sm2-2.0.1-apple-arm64.zip && rm sm2-2.0.1-apple-arm64.zip && chmod +x sm2
 ```
 
-**OSX/Apple (older Intel cpus)**
+#### OSX/Apple (older Intel cpus)
 
 ```shell
 curl -L -O https://github.com/hmrc/sm2/releases/download/v2.0.1/sm2-2.0.1-apple-intel.zip && unzip sm2-2.0.1-apple-intel.zip && rm sm2-2.0.1-apple-intel.zip && chmod +x sm2
@@ -50,41 +53,40 @@ curl -L -O https://github.com/hmrc/sm2/releases/download/v2.0.1/sm2-2.0.1-apple-
 
 If everything has worked you should have an executable called `sm2`.
 
-2. Move the executable somewhere on your systems $PATH.
-3. Run `sm2` from the terminal and follow the instructions to configure your system (if its not already set up)
-4. For more information, see [USERGUIDE.md](USERGUIDE.md)
+1. Move the executable somewhere on your systems $PATH.
+2. Run `sm2` from the terminal and follow the instructions to configure your system (if its not already set up)
+3. For more information, see [USERGUIDE.md](USERGUIDE.md)
 
 Alternatively you can download and decompress sm2 yourself from the [releases](https://github.com/hmrc/sm2/releases/latest) section. Please note OSX/Apple users will have to [allow `sm2` to run](https://support.apple.com/en-gb/guide/mac-help/mh40616/mac) when downloading via the browser.
 
 ### Setup
+
 If you are upgrading from the original service-manager, sm2 will use your existing config.
 
 By default `sm2` will create a workspace folder in `$HOME/.sm2`. If you want to override this default you can do so by following these steps:
 
-1. Create a workspace directory somewhere in your $HOME directory. The directory can be named anything.
-```mkdir /home/username/.servicemanager```
-2. Set an environment variable called `WORKSPACE` that points to this directory.
-```shell
-export WORKSPACE=/path/to/workspace
-```
+1. Create a workspace directory somewhere in your $HOME directory. The directory can be named anything: ```mkdir /home/username/.servicemanager```
+2. Set an environment variable called `WORKSPACE` that points to this directory.```export WORKSPACE=/path/to/workspace```
 Once working add the export to your .bashrc and/or .profile to set it permanently.
-
-2. Using git, clone a copy of service-manager-config into your workspace folder (which will be `$HOME/.sm2` by default unless you've overriden it via `$WORKSPACE`).
+3. Using git, clone a copy of service-manager-config into your workspace folder (which will be `$HOME/.sm2` by default unless you've overriden it via `$WORKSPACE`).
 
 ### Post install/setup checkers
+
 You can check everything is setup correctly by running:
-```shell
-sm2 --diagnostic
-```
+```sm2 --diagnostic```
 
 ### Enabling tab completion
+
 Run the commands below which will copy a completion script into a file called `sm2.bash` in the directory
 `~/.local/share/bash-completion/completions`, if the directory doesn't exist then it will create it.
+
 ```shell
 mkdir -p ~/.local/share/bash-completion/completions
 sm2 --generate-autocomplete > ~/.local/share/bash-completion/completions/sm2.bash
 ```
+
 If you are using zsh as your shell and not using Oh-My-Zsh then you may need to enable bash-completion support by adding the following to your `~/.zshrc` file
+
 ```shell
 # Load bash completion functions
 autoload -Uz +X compinit && compinit
@@ -92,53 +94,62 @@ autoload -Uz +X bashcompinit && bashcompinit
 source ~/.local/share/bash-completion/completions/sm2.bash
 ```
 
-
 ### Upgrading Service Manager 2
+
 As of v1.0.9 `sm2` can update itself - simply run `sm2 -update`. You will need to ensure `sm2` is available on your `$PATH`.
 
 Alternatively, upgrades are a simple matter of downloading the latest version of sm2 and overwriting the `sm2` binary with the new one.
 
 If you are unsure where `sm2` is installed you can use the whereis command to find it:
+
 ```shell
 $ whereis sm2
 sm2 : /usr/local/bin/sm2
 ```
 
-
-# Using Service Manager
+## Using Service Manager
 
 ### Starting a service (-start)
+
 From your terminal type:
+
 ```shell
 $ sm2 -start SERVICE_NAME
 Starting 1 services on 2 workers
  SERVICE_NAME         [====================][100%] Done
 ```
+
 This will download the latest release of that service, configure it and start it up.
 Services names are all uppercase with underscores instead of dashes.
 
 The download will only happen once, after that the service will be cached in your `$WORKSPACE` folder until a new version is released.
 
 ### Starting a group of services
+
 Much like starting a single service a group of services (defined by an entry in profiles.json) can be started by typing
+
 ```shell
-$ sm2 -start PROFILE_NAME
+sm2 -start PROFILE_NAME
 ```
 
 Alternatively you can start more than one service at once by typing multiple service and/or profile names
+
 ```shell
-$ sm2 -start SERVICE_ONE SERVICE_TWO
+sm2 -start SERVICE_ONE SERVICE_TWO
 ```
 
 ### Starting specific versions
+
 If you need to run a specific version of a service you can do so by adding a colon followed by the version number to the service name, e.g.
+
 ```shell
-$ sm2 -start SERVICENAME:1.2.3
+sm2 -start SERVICENAME:1.2.3
 ```
 
 You can also start a specific version of a service using the older `-r` (release) flag:
+
 ```shell
-$ sm2 -start SERVICENAME -r 1.2.3
+sm2 -start SERVICENAME -r 1.2.3
 ```
 
 When starting more than one service, the `-r` flag only applies to the first service in the list.
@@ -146,39 +157,44 @@ When starting more than one service, the `-r` flag only applies to the first ser
 | Option         | Description                                                                                                          |
 |----------------|----------------------------------------------------------------------------------------------------------------------|
 | -appendArgs    | A json map of extra args for services being started: `{"SERVICE_NAME":["-DFoo=Bar","SOMETHING"]}`                    |
-| -clean         | Deletes the cached version of a service to force a redownload.
-| -offline       | Start a service using the cached version. Fails is not in cache. `-offline` can be used by itself to list available services.
-| -port 1234     | Overrides the service’s default port to use the supplied port instead.
-| -noprogress    | Disabled the progress bars. Useful for scripting and automation.
-| -src           | Runs the service(s) from source instead of downloading the binary artifacts. Service manager will attempt to clone the repository and start the service using sbt start. Assumes the system has git configured and a working sbt installation.
-| -update-config | Updates workspace copy of service-manager from git. Will fail if there are uncommitted changes or if the config repo is not on the main branch.
-| -wait 120      | Waits a given number of seconds (default 30) for the service to respond to a healthcheck after startup.
-| -workers 4     | Sets the number of concurrent downloads (default 2). Can also be set via SM_WORKERS environment variable.
+| -clean         | Deletes the cached version of a service to force a redownload. |
+| -offline       | Start a service using the cached version. Fails is not in cache. `-offline` can be used by itself to list available services. |
+| -port 1234     | Overrides the service’s default port to use the supplied port instead. |
+| -noprogress    | Disabled the progress bars. Useful for scripting and automation. |
+| -src           | Runs the service(s) from source instead of downloading the binary artifacts. Service manager will attempt to clone the repository and start the service using sbt start. Assumes the system has git configured and a working sbt installation. |
+| -update-config | Updates workspace copy of service-manager from git. Will fail if there are uncommitted changes or if the config repo is not on the main branch. |
+| -wait 120      | Waits a given number of seconds (default 30) for the service to respond to a healthcheck after startup. |
+| -workers 4     | Sets the number of concurrent downloads (default 2). Can also be set via SM_WORKERS environment variable. |
 
 ### Stopping services (-stop)
+
 ```shell
-$ sm2 -stop SERVICE_NAME
+sm2 -stop SERVICE_NAME
 ```
 
 As with the start command you can pass a profile name, or multiple service names to stop more than one service at once.
 If you wish to stop all services managed by service manager you can use:
+
 ```shell
-$ sm2 -stop-all
+sm2 -stop-all
 ```
 
 You can also restart services using:
+
 ```shell
-$ sm2 -restart SERVICE_NAME
+sm2 -restart SERVICE_NAME
 ```
 
 When restarting a service or profile, you can specify `-latest` to check for a new version before restarting:
+
 ```shell
-$ sm2 -restart SERVICE_NAME -latest
+sm2 -restart SERVICE_NAME -latest
 ```
 
-
 ### Checking the status of services (-s or -status)
+
 You can check what services are running using the status command
+
 ```shell
 $ sm2 -s
 +------------------------------------+-----------+---------+-------+--------+
@@ -198,25 +214,29 @@ Services will be in one of three states:
 | PASS  | The service has started and its health-check endpoint is responding  |
 | FAIL  | The process failed to start, or has started and is no longer running |
 
-
 Discovering what services are available (-list and -search)
 If you are unsure the exact name of a service, want to see what services are available or want to know what services make up a given profile you can use:
+
 ```shell
-$ sm2 -list
+sm2 -list
 ```
 
 to list all available services and profiles, or
+
 ```shell
-$ sm2 -search SERVICE
+sm2 -search SERVICE
 ```
 
 To search for services and profiles that match the given term. You can supply any valid regex as a parameter to `-search`.
 
 ### Discover what port a service uses (-ports)
+
 ```shell
 sm2 -ports
 ```
+
 Shows every configured service along with the port it will run on. The output is intended to be easily piped into grep to allow for looking up a specific service or port
+
 ```shell
 sm2 -ports | grep CATALOGUE_FRONTEND
 # or
@@ -224,29 +244,33 @@ sm2 -ports | grep 9540
 ```
 
 ## Troubleshooting Service Manager
+
 Sometimes a service will fail to start up. To help determine why, service manager has some built-in features to help diagnose failing services.
 
 ### Diagnostic Mode (-diagnostic)
+
 Before doing anything else, it’s worth running service-manager’s self-checks to ensure it is installed correctly.
+
 ```shell
 $ sm2 -diagnostic
 version: 2.0.1
   build: ef49b60
-OS:		 OK (linux, amd64)
-JAVA:		 OK (11.0.17)
-GIT:		 OK (git version 2.38.1)
-NET		 OK (VPN check timeout 20s)
-VPN DNS		 OK (IP Address of artefactory resolvable
-VPN:		 OK (artifactory/api/system/ping responds to ping)
-WORKSPACE:	 OK (/home/user.servicemanager)
-CONFIG:		 WARN: Local version (abe9d50) is not up to date with remote version (eaaa410)
+OS:            OK (darwin, arm64)
+JAVA:          OK (11.0.26)
+GIT:           OK (git version 2.49.0)
+CONFIG:        OK (Local version is up to date with remote version (5d4bffc))
+WORKSPACE:     OK (/Users/USER/.sm2/install/install)
+VPN DNS:       OK (IP Address of artefacts.tax.service.gov.uk resolves to [ip1, ip2])
+VPN:           OK (https://artefacts.tax.service.gov.uk/artifactory/api/system/ping responds to ping)
 ```
 
 This will do a number of checks to ensure sm2 is able to download and install services.
 Also when raising a support request it is often helpful to include the output of this command.
 
 ### Debug Mode (-debug SERVICE_NAME)
+
 If your service is failing to start, you can get a detailed breakdown of what was attempted and what succeeded using the -debug flag.
+
 ```shell
 $ sm2 -debug SERVICE_NAME
 
@@ -256,39 +280,41 @@ SERVICE_CONFIGS: version 0.130.0
 Checking .state file...
 The .state file says SERVICE_CONFIGS version 0.130.0 was started on 2022-11-11 10:31:21.310730227 +0000 UTC with PID 24384
 It was run with the following args:
-	- -Dconfig.resource=application.conf
-	- -Dapplication.router=testOnlyDoNotUseInAppConf.Routes
-	- -J-Xmx256m
-	- -J-Xms64m
-	- -Dservice.manager.serviceName=SERVICE_CONFIGS
-	- -Dservice.manager.runFrom=0.130.0
-	- -Duser.home=/home/user/.servicemanager/install/service-configs
-	- -Dhttp.port=8460
+    - -Dconfig.resource=application.conf
+    - -Dapplication.router=testOnlyDoNotUseInAppConf.Routes
+    - -J-Xmx256m
+    - -J-Xms64m
+    - -Dservice.manager.serviceName=SERVICE_CONFIGS
+    - -Dservice.manager.runFrom=0.130.0
+    - -Duser.home=/home/user/.servicemanager/install/service-configs
+    - -Dhttp.port=8460
 Checking pid: 24384 is running...
 Pid 24384 exists, service is probably running...pinging service on port 8460...
 Service responded to ping on [http://localhost:8460/ping/ping], its alive.
 Log files in /home/user/.servicemanager/hmrc/install/service-configs/service-configs-0.130.0/logs:
-	          access.log  0
-	       connector.log  0
-	 service-configs.log  7099
-	          stdout.log  8415
+              access.log  0
+           connector.log  0
+     service-configs.log  7099
+              stdout.log  8415
 
 ```
 
 Debug mode checks what was requested, what was actually installed, what was started and with what parameters and if there are any logs or healthcheck responses.
 
 ### Viewing Logs (-logs SERVICE_NAME)
+
 If a service is running and you simply want to check the stdout/stderr of the process you can view it using:
+
 ```shell
 sm2 -logs SERVICE_NAME
 ```
-
 
 ## Developing using service-manager
 
 Ok so you’ve installed service manager and started some services, fantastic, but how does this fit into your development process?
 
 Generally we’d recommend the following
+
 1. Checkout the source code for the service you’re working on
 2. Start the service from the IDE
 3. Use service manager to start the profile related to the service your developing
@@ -297,32 +323,39 @@ Generally we’d recommend the following
 Alternatively you can start the profile beforehand and just stop the individual service you want to work on.
 
 ## ASSETS_FRONTEND
+
 Assets Frontend is a service that only exists in service-manager responsible for serving up static assets (that would normally come from a CDN) to local services.
 
 The original assets-frontend (as defined in services.json as ASSETS_FRONTEND) will not work in service manager 2. However, a new service, ASSETS_FRONTEND_2 is available as a drop-in replacement offering
 
 ### New version
+
 Assets frontend 2 is a drop-in replacement for Assets Frontend.
 
 The new version of assets frontend ASSETS_FRONTEND_2 is a complete rewrite. It is a scala service, so no longer requires a specific version of python to work and will only download the assets when they are requested rather than downloading 100s of megabytes of assets on start-up or being limited to one specific version.
 
 ### How to start ASSETS_FRONTEND_2
+
 It can be started the same as any other service.
+
+```shell
+sm2 -start ASSETS_FRONTEND_2
 ```
-$ sm2 -start ASSETS_FRONTEND_2
-```
+
 You do not need to specify which version of the asset you wish to use, just run your service(s) as normal and ASSETS_FRONTEND_2 will download them when requested.
 The individual asset bundles are little more than 1 meg in size and will be cached so the download time should not be noticeable.
 
 Assets frontend 2 will also work in the original service manager, so there's no reason not to update your profiles to use it.
 
 ## Configuration
+
 ### Environment Variables
+
 Service manager has a few options that can be set via environment variables. Typically you should set these by adding an export statement to your .bash_profile or .profile file in your home directory (this will vary depending on your operating system)
+
 ```shell
 export WORKSPACE=/home/myusername/.servicemanager
 ```
-
 
 | Environment Variable | Description                                                                                           |
 |----------------------|-------------------------------------------------------------------------------------------------------|
@@ -330,7 +363,8 @@ export WORKSPACE=/home/myusername/.servicemanager
 | SM_TIMEOUT | Overrides the default http timeouts. Useful if you have a very slow internet connection |
 | SM_WORKERS | Sets the number of concurrent downloads. Same as using the -workers flag. |
 
- ### Service Manager Config
+### Service Manager Config
+
 To run service manager you will require a folder named service-manager-config to exist inside your WORKSPACE folder. It should typically be a clone of a git repository.
 Service-manager-config is expected to have the following structure:
 
@@ -341,6 +375,7 @@ Service-manager-config is expected to have the following structure:
 | profiles.json | Defines groups of services that should be started together |
 
 ### Setting Scala Version
+
 For Scala artifacts, the artifact name will include the Scala version:
 
 ```json
@@ -351,15 +386,14 @@ For Scala artifacts, the artifact name will include the Scala version:
 
 However, you may represent the Scala version with `_%%` instead. Then service-manager will use the latest artifact version it finds, regardless of Scala version. This should make it simpler to maintain:
 
-
 ```json
     "binary": {
       "artifact": "example-service_%%"
-	}
+    }
 ```
 
-
 ## Building/Developing Service-Manager-2
+
 SM2 has no external dependencies other than go 1.20+. You can build it locally via:
 
 ```bash
@@ -367,6 +401,7 @@ go build
 ```
 
 When building a new release, use the included makefile:
+
 ```bash
 make build_all package
 ```
@@ -380,6 +415,7 @@ make test
 ```
 
 To run tests for the subdirectory you are currently in:
+
 ```bash
 go test
 ```
@@ -401,9 +437,11 @@ bash update-nixpkgs.sh
 ```
 
 To build with shell:
+
 ```bash
 nix-shell --run 'go build'
 ```
+
 to create `./sm2`
 
 or to build locally:
@@ -411,4 +449,5 @@ or to build locally:
 ```bash
 nix-build
 ```
+
 to create `./result/bin/sm2`

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module sm2
 
-go 1.20
+go 1.24

--- a/servicemanager/artifactory.go
+++ b/servicemanager/artifactory.go
@@ -146,7 +146,11 @@ func (sm *ServiceManager) getLatestVersion(group string, artifact string) (Maven
 	url := sm.Config.ArtifactoryRepoUrl + path.Join("/", group, artifact, "maven-metadata.xml")
 
 	// download metadata
-	ctx := sm.NewShortContext()
+	ctx, cancel := sm.NewShortContext()
+
+	// cleanup the context
+	defer cancel()
+
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return MavenMetadata{}, err

--- a/servicemanager/artifactory_test.go
+++ b/servicemanager/artifactory_test.go
@@ -3,7 +3,6 @@ package servicemanager
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -448,8 +447,7 @@ func TestParseValidMetadata(t *testing.T) {
 }
 
 func TestDownloadAndDecompress(t *testing.T) {
-
-	outdir, err := ioutil.TempDir(os.TempDir(), "test-downloader*")
+	outdir, err := os.MkdirTemp(os.TempDir(), "test-downloader*")
 	AssertNotErr(t, err)
 	defer os.RemoveAll(outdir)
 

--- a/servicemanager/config.go
+++ b/servicemanager/config.go
@@ -45,7 +45,8 @@ func loadServicesFromFile(serviceFile string) (*Services, error) {
 }
 
 // @speed do we need to cache the whole thing? we only ever look up 1 profile
-//  maybe just load, find the profile and discard the rest?
+//
+//	maybe just load, find the profile and discard the rest?
 func loadProfilesFromFile(profileFileName string) (*Profiles, error) {
 	profiles := make(Profiles, 600)
 

--- a/servicemanager/debug.go
+++ b/servicemanager/debug.go
@@ -2,7 +2,7 @@ package servicemanager
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 )
 
@@ -77,7 +77,7 @@ func (sm *ServiceManager) showDebug(serviceName string) {
 	}
 	// show what logs we have
 	logDir := path.Join(installFile.Path, "logs")
-	files, err := ioutil.ReadDir(logDir)
+	files, err := os.ReadDir(logDir)
 	if err != nil {
 		fmt.Printf("unable to read log dir: %s\n%s\n", logDir, err)
 		return
@@ -85,7 +85,8 @@ func (sm *ServiceManager) showDebug(serviceName string) {
 
 	fmt.Printf("Log files in %s:\n", logDir)
 	for _, file := range files {
-		fmt.Printf("\t%20s  %d\n", file.Name(), file.Size())
+		info, _ := file.Info()
+		fmt.Printf("\t%20s  %d\n", file.Name(), info.Size())
 	}
 
 }

--- a/servicemanager/list.go
+++ b/servicemanager/list.go
@@ -2,7 +2,7 @@ package servicemanager
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"regexp"
 	"sort"
@@ -119,7 +119,7 @@ func printServiceListPlain(keys []string) {
 // scrapes the install files and prints out what versions are installed and available
 func (sm *ServiceManager) ListServicesAvailableOffline() {
 
-	files, err := ioutil.ReadDir(sm.Config.TmpDir)
+	files, err := os.ReadDir(sm.Config.TmpDir)
 
 	if err != nil {
 		fmt.Printf("failed to read the workspace dir, %s\n", err)

--- a/servicemanager/reverseproxy.go
+++ b/servicemanager/reverseproxy.go
@@ -47,7 +47,7 @@ func (sm *ServiceManager) StartProxy() {
 
 		if proxyTo, ok := routes[pathPrefix]; ok {
 			if sm.Commands.Verbose {
-				log.Print(fmt.Sprintf("%s\t%s  ->  %s\n", req.Method, req.URL.Path, proxyTo))
+				log.Printf("%s\t%s  ->  %s\n", req.Method, req.URL.Path, proxyTo)
 			}
 			req.Header.Add("X-Forwarded-Host", req.Host)
 			req.Header.Add("X-Origin-Host", proxyTo)

--- a/servicemanager/servicemanager.go
+++ b/servicemanager/servicemanager.go
@@ -74,13 +74,12 @@ func (sm ServiceManager) PrintVerbose(s string, args ...interface{}) {
 	}
 }
 
-func (sm *ServiceManager) NewShortContext() context.Context {
+func (sm *ServiceManager) NewShortContext() (context.Context, context.CancelFunc) {
 	ttl := sm.Config.TimeoutShort
 	if ttl == 0 {
 		ttl = DEFAULT_SHORT_TIMEOUT * time.Second
 	}
-	ctx, _ := context.WithTimeout(context.Background(), ttl)
-	return ctx
+	return context.WithTimeout(context.Background(), ttl)
 }
 
 // based on config, find the directory a service is installed into.

--- a/servicemanager/startfromsource.go
+++ b/servicemanager/startfromsource.go
@@ -112,11 +112,3 @@ func (sm ServiceManager) sbtBuildAndRun(srcDir string, service Service) (ledger.
 	}
 	return state, nil
 }
-
-func removeSrcDir(installDir string) error {
-	srcPath := path.Join(installDir, "src")
-	if Exists(srcPath) {
-		return os.RemoveAll(srcPath)
-	}
-	return nil
-}

--- a/servicemanager/startservice.go
+++ b/servicemanager/startservice.go
@@ -355,7 +355,6 @@ func (sm *ServiceManager) asyncStart(services []ServiceAndVersion) {
 			workerPlural = "worker"
 		}
 
-
 		fmt.Printf("Starting %d services on %d %s\n", len(services), sm.Commands.Workers, workerPlural)
 	}
 

--- a/servicemanager/startservice_test.go
+++ b/servicemanager/startservice_test.go
@@ -1,7 +1,6 @@
 package servicemanager
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -12,7 +11,7 @@ import (
 /*
 func TestInstallService(t *testing.T) {
 
-	installDir, err := ioutil.TempDir(os.TempDir(), "test-install*")
+	installDir, err := os.MkdirTemp(os.TempDir(), "test-install*")
 	AssertNotErr(t, err)
 
 	service := Service{
@@ -37,7 +36,7 @@ func TestInstallService(t *testing.T) {
 
 func TestRemoveExistingVersion(t *testing.T) {
 
-	baseDir, err := ioutil.TempDir(os.TempDir(), "test-removeExisting*")
+	baseDir, err := os.MkdirTemp(os.TempDir(), "test-removeExisting*")
 	AssertNotErr(t, err)
 	installDir := path.Join(baseDir, "foo")
 	serviceDir := path.Join(installDir, "foo-1.0.1")
@@ -55,7 +54,7 @@ func TestRemoveExistingVersion(t *testing.T) {
 }
 
 func TestRemoveRunningPid(t *testing.T) {
-	baseDir, err := ioutil.TempDir(os.TempDir(), "test-removeRunningPid*")
+	baseDir, err := os.MkdirTemp(os.TempDir(), "test-removeRunningPid*")
 	AssertNotErr(t, err)
 	pidPath := path.Join(baseDir, "RUNNING_PID")
 	AssertNotErr(t, os.WriteFile(pidPath, []byte{}, 0755))

--- a/servicemanager/status_test.go
+++ b/servicemanager/status_test.go
@@ -127,13 +127,13 @@ func TestFindStatusesSortsResultsAlphabetically(t *testing.T) {
 func TestStatusWrapsServiceNames(t *testing.T) {
 	sb := bytes.NewBufferString("")
 	statuses := []serviceStatus{
-		serviceStatus{0, 1, "SHORT_ID", "1.2.3", "PASS"},
-		serviceStatus{123, 10801, "THE_SERVICE_IS_35_CHARS_DO_NOT_WRAP", "42.999.1", "PASS"},
-		serviceStatus{2, 3, "SERVICE_IS_38_CHARS_STILL_CROP_IT_OKAY", "1.5", "PASS"},
-		serviceStatus{3, 4, "SERVICE_IS_39_CHARS_SO_WRAP_OVERFLOW_OK", "2.8", "PASS"},
-		serviceStatus{4, 5, "SERVICE_IS_54_CHARS_SO_DEFINITELY_WRAP_THE_OVERFLOW_OK", "3.1", "PASS"},
-		serviceStatus{5, 6, "SERVICE_IS_73_CHARS_SO_DEFINITELY_CROP_THE_SECOND_LINE_SO_NO_3RD_OVERFLOW", "3.2", "PASS"},
-		serviceStatus{6, 7, "SERVICE_IS_74_CHARS_SO_DEFINITELY_WRAP_THE_3RD_LINE_SO_WE_CAN_SEE_OVERFLOW", "3.3", "PASS"},
+		{0, 1, "SHORT_ID", "1.2.3", "PASS"},
+		{123, 10801, "THE_SERVICE_IS_35_CHARS_DO_NOT_WRAP", "42.999.1", "PASS"},
+		{2, 3, "SERVICE_IS_38_CHARS_STILL_CROP_IT_OKAY", "1.5", "PASS"},
+		{3, 4, "SERVICE_IS_39_CHARS_SO_WRAP_OVERFLOW_OK", "2.8", "PASS"},
+		{4, 5, "SERVICE_IS_54_CHARS_SO_DEFINITELY_WRAP_THE_OVERFLOW_OK", "3.1", "PASS"},
+		{5, 6, "SERVICE_IS_73_CHARS_SO_DEFINITELY_CROP_THE_SECOND_LINE_SO_NO_3RD_OVERFLOW", "3.2", "PASS"},
+		{6, 7, "SERVICE_IS_74_CHARS_SO_DEFINITELY_WRAP_THE_3RD_LINE_SO_WE_CAN_SEE_OVERFLOW", "3.3", "PASS"},
 	}
 	expectedOutput :=
 		`+---------------------------------------+-----------+---------+-------+--------+
@@ -177,8 +177,8 @@ func TestStatusWrapsServiceNames(t *testing.T) {
 func TestStatusExpandsServiceName(t *testing.T) {
 	sb := bytes.NewBufferString("")
 	statuses := []serviceStatus{
-		serviceStatus{0, 1, "SHORT_ID", "1.2.3", "PASS"},
-		serviceStatus{6, 7, "SERVICE_IS_VERY_LONG_LIKE_REALLY_REALLY_LONG_BUT_WERE_OK", "3.3", "PASS"},
+		{0, 1, "SHORT_ID", "1.2.3", "PASS"},
+		{6, 7, "SERVICE_IS_VERY_LONG_LIKE_REALLY_REALLY_LONG_BUT_WERE_OK", "3.3", "PASS"},
 	}
 	expectedOutput := `+----------------------------------------------------------+-----------+---------+-------+--------+
 | Name                                                     | Version   | PID     | Port  | Status |
@@ -386,24 +386,22 @@ func TestVerifyIsRunning(t *testing.T) {
 		{0, 0, "BAR", "1.0.0", PASS},
 	}
 
-	output := bytes.NewBufferString("")
-
 	// happy case
-	if verifyIsRunning(services, statuses, output) == false {
+	if verifyIsRunning(services, statuses) == false {
 		t.Errorf("verifyIsRunning returned false when it should be true!")
 	}
 
 	// unhappy cases
-	if verifyIsRunning(services, statuses[:1], output) {
+	if verifyIsRunning(services, statuses[:1]) {
 		t.Errorf("verifyIsRunning returned a false positive")
 	}
 
-	if verifyIsRunning(services, []serviceStatus{}, output) {
+	if verifyIsRunning(services, []serviceStatus{}) {
 		t.Errorf("verifyIsRunning returned a false positive with an empty status list")
 	}
 
 	statuses[0].health = FAIL
-	if verifyIsRunning(services, statuses, output) {
+	if verifyIsRunning(services, statuses) {
 		t.Errorf("verifyIsRunning returned true when status was FAILED")
 	}
 }

--- a/servicemanager/update.go
+++ b/servicemanager/update.go
@@ -4,7 +4,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -90,12 +90,12 @@ func downloadAndInstall(versionToInstall string, workspaceInstallPath string, in
 	downloadLocation := workspaceInstallPath + "/sm2"
 
 	// convert `darwin` to `apple` for download url
-	var os string
+	var osForUrl string
 	switch runtime.GOOS {
 	case "darwin":
-		os = "apple"
+		osForUrl = "apple"
 	case "linux":
-		os = "linux"
+		osForUrl = "linux"
 	default:
 		log.Fatalf("unsupported OS: %s", runtime.GOOS)
 	}
@@ -111,7 +111,7 @@ func downloadAndInstall(versionToInstall string, workspaceInstallPath string, in
 		log.Fatalf("unsupported CPU architecture %s", runtime.GOARCH)
 	}
 
-	downloadUrl := fmt.Sprintf("https://github.com/hmrc/sm2/releases/download/v%s/sm2-%s-%s-%s.zip", versionToInstall, versionToInstall, os, arch)
+	downloadUrl := fmt.Sprintf("https://github.com/hmrc/sm2/releases/download/v%s/sm2-%s-%s-%s.zip", versionToInstall, versionToInstall, osForUrl, arch)
 
 	fmt.Printf("Downloading %s...\n", downloadUrl)
 
@@ -121,7 +121,7 @@ func downloadAndInstall(versionToInstall string, workspaceInstallPath string, in
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
@@ -139,14 +139,14 @@ func downloadAndInstall(versionToInstall string, workspaceInstallPath string, in
 			}
 			defer rc.Close()
 
-			fileData, err := ioutil.ReadAll(rc)
+			fileData, err := io.ReadAll(rc)
 			if err != nil {
 				return err
 			}
 
 			fmt.Printf("Unzipping into %s...\n", downloadLocation)
 
-			err = ioutil.WriteFile(downloadLocation, fileData, 0755)
+			err = os.WriteFile(downloadLocation, fileData, 0755)
 			if err != nil {
 				return err
 			}

--- a/servicemanager/updateconfig.go
+++ b/servicemanager/updateconfig.go
@@ -5,8 +5,10 @@ import (
 	"path"
 )
 
-/* Attempts to git pull the service-manager-config in $WORKSPACE
-   Fails if not on main, bound to the --update-config cmd
+/*
+Attempts to git pull the service-manager-config in $WORKSPACE
+
+	Fails if not on main, bound to the --update-config cmd
 */
 func updateConfig(configRepo string) error {
 

--- a/servicemanager/utils.go
+++ b/servicemanager/utils.go
@@ -26,14 +26,6 @@ func crop(s string, width int) string {
 	return s[:width]
 }
 
-func addDelimiter(initialStr string, separator string, step int) string {
-	str := initialStr
-	for i := step; i < len(str); i += step + 1 {
-		str = str[:i] + separator + str[i:]
-	}
-	return str
-}
-
 // Splits a string into equal `width` sized partitons.
 func partition(s string, width int) []string {
 	split := []string{}

--- a/servicemanager/utils_test.go
+++ b/servicemanager/utils_test.go
@@ -5,10 +5,10 @@ import "testing"
 func TestPartition(t *testing.T) {
 
 	testData := map[string][]string{
-		"abcdef": []string{"ab", "cd", "ef"},
-		"abcde":  []string{"ab", "cd", "e"},
-		"ab":     []string{"ab"},
-		"":       []string{},
+		"abcdef": {"ab", "cd", "ef"},
+		"abcde":  {"ab", "cd", "e"},
+		"ab":     {"ab"},
+		"":       {},
 	}
 
 	for input, output := range testData {

--- a/servicemanager/vpn.go
+++ b/servicemanager/vpn.go
@@ -11,7 +11,10 @@ import (
 // to artifactory using a http client with a short timeout.
 func checkVpn(client *http.Client, config ServiceManagerConfig) (bool, error) {
 
-	ctx, _ := context.WithTimeout(context.Background(), config.TimeoutShort)
+	ctx, cancel := context.WithTimeout(context.Background(), config.TimeoutShort)
+
+	// cleanup the context
+	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, "GET", config.ArtifactoryPingUrl, nil)
 	if err != nil {


### PR DESCRIPTION
fix deprecated methods.

Because i dont have much exprience with go in some cases the `cancel()` should be `defer cancel()` but i dont understand exactly when, these changes still works, i started all services locally for a few different services and it still works